### PR TITLE
Fix onchain logic

### DIFF
--- a/src/Bounty.hs
+++ b/src/Bounty.hs
@@ -31,33 +31,15 @@ module Bounty where
 
 import           Control.Monad        hiding (fmap)
 import           Data.Aeson           (FromJSON, ToJSON)
-import           Data.List            (intersect, union)
-import qualified Data.Map             as Map
-import           Data.String          (IsString (..))
-import           Data.Text            (Text)
-import           Data.Void            (Void)
 import           GHC.Generics         (Generic)
 import           Ledger               hiding (singleton)
-import           Ledger.Ada           as Ada
-import           Ledger.Constraints   as Constraints
-import qualified Ledger.Contexts      as Validation
 import           Ledger.Credential
-import           Ledger.Index         as Index
 import qualified Ledger.Typed.Scripts as Scripts
 import           Ledger.Value         as Value
-import           Playground.Contract  (NonEmpty (..), ToSchema,
-                                       ensureKnownCurrencies, printJson,
-                                       printSchemas, stage)
-import           Playground.TH        (ensureKnownCurrencies, mkKnownCurrencies,
-                                       mkSchemaDefinitions)
-import           Playground.Types     (KnownCurrency (..))
-import           Plutus.Contract      as Contract
 import qualified PlutusTx
-import           PlutusTx.IsData
 import           PlutusTx.Maybe
 import           PlutusTx.Prelude     hiding (Semigroup (..), unless)
-import           Prelude              (Semigroup (..), Show, String, show)
-import           Text.Printf          (printf)
+import           Prelude              (Show)
 
 data Bounty = Bounty
   { expiration           :: !POSIXTime,

--- a/src/Bounty.hs
+++ b/src/Bounty.hs
@@ -185,9 +185,9 @@ containsPot info o =
     Just PotDatum -> True
     _             -> False
 
-{-# INLINABLE getOutputPDatum #-}
-getOutputPDatum :: TxInfo -> [TxOut] -> Maybe TxOut
-getOutputPDatum info txOuts = find (containsPot info) txOuts
+{-# INLINABLE findOutputPDatum #-}
+findOutputPDatum :: TxInfo -> [TxOut] -> Maybe TxOut
+findOutputPDatum info = find (containsPot info)
 
 {-# INLINABLE startCollectionDatum #-}
 startCollectionDatum :: Maybe BountyDatum -> Bool
@@ -245,7 +245,7 @@ checkSpending ctx bounty =
   let txInfo = scriptContextTxInfo ctx
       txOuts = txInfoOutputs txInfo
       datumBox = findOutputForClass (bCollectionToken bounty) txOuts >>= findBountyDatum txInfo
-      potTxOut = getOutputPDatum txInfo txOuts
+      potTxOut = findOutputPDatum txInfo txOuts
       potBox = potTxOut >>= findBountyDatum txInfo
    in validateUseOfPot bounty potTxOut potBox datumBox
 


### PR DESCRIPTION
Changes:
- Fix logic where it bails (though `traceError`) due to invalid input. If invalid input's received, the validator should always validate to False instead of throwing an error. Also trace calls aren't supposed to be used in production environment because they break referential transparency. They are only for testing purpose.
- Remove unused variables
- Fix shadowed variables. These are mainly caused by:
  - unprefixed record field names
  - library imports, e.g. `before`, `after`, `outputs` etc.
- Remove unused imports in Bounty.hs.

I will rebase this PR to ADAOCommunity's repo once https://github.com/ADAOcommunity/Bounty/pull/4 has been merged.